### PR TITLE
Update azure-pipelines.yml to use main branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- master
+- main
 
 variables:
   # Agent VM image name


### PR DESCRIPTION
This PR updates the azure-pipelines.yml file to use the `main` branch instead of `master`. It has been automatically generated and this might not have worked correctly, so please check it carefully.